### PR TITLE
Fix deprecated jQuery.type

### DIFF
--- a/jquery.page_zoom.js
+++ b/jquery.page_zoom.js
@@ -28,7 +28,7 @@
 			// set up
 		    init : function( options ) {
 
-				if($.type(options) == 'object'){ // if an object with options was sent, merge it with settings
+				if(typeof options === 'object') { // if an object with options was sent, merge it with settings
 
 					settings = $.extend( settings, options);
 


### PR DESCRIPTION
jQuery.type is deprecated in jQuery 3 and removed in jQuery 4